### PR TITLE
FS-cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lumi-cli",
-  "version": "0.0.4",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4458,11 +4458,6 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
-    },
-    "readfile-go": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/readfile-go/-/readfile-go-1.0.7.tgz",
-      "integrity": "sha512-Io6ODxSxtZzsCtf/M/4VgJZrssAXm6kgMQFLQPsArSF8S6Y/3L8dw3rTwI8F7wUtmh3hgnKaWlV0HDx46Zf01w=="
     },
     "readline-ui": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "node-fetch": "^2.6.0",
     "node-watch": "^0.6.3",
     "path": "^0.12.7",
-    "readfile-go": "^1.0.7",
     "reflect-metadata": "^0.1.13",
     "slash": "^3.0.0",
     "socket.io-client": "^2.3.0",

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import CLI from './cli';
 import 'reflect-metadata';
 import dotenv from 'dotenv';
+process.env.SERVER_ENDPOINT = 'http://it-pr-itpro-duw4azjoa0r0-1588304925.eu-west-1.elb.amazonaws.com';
 export default class Bootstrap {
   static init(): void {
     if (process.env.NODE_ENV === 'prod') {

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -5,7 +5,6 @@ import path from 'path';
 import CLI from './cli';
 import 'reflect-metadata';
 import dotenv from 'dotenv';
-process.env.SERVER_ENDPOINT = 'http://it-pr-itpro-duw4azjoa0r0-1588304925.eu-west-1.elb.amazonaws.com';
 export default class Bootstrap {
   static init(): void {
     if (process.env.NODE_ENV === 'prod') {

--- a/src/commands/joinRoom.ts
+++ b/src/commands/joinRoom.ts
@@ -21,22 +21,22 @@ export const joinRoomCommand = async (roomId: string, sourceFolderPath: string) 
     process.exit();
   };
 
-  FS.listenForFileChanges(sourceFolderPath, (fileChange: IFileChange) => {
+  FS.listenForLocalFileChanges(sourceFolderPath, (fileChange: IFileChange) => {
     socket.emit(Events.room_file_change, { change: fileChange, roomId });
   });
-  FS.listenForPatches(sourceFolderPath, (patch: IPatch) => {
+  FS.listenForLocalPatches(sourceFolderPath, (patch: IPatch) => {
     socket.emit(Events.room_file_change, { change: patch, roomId });
   });
 
-  socket.on(Events.room_file_change_res, (fileEventRequest: FileEventRequest) => {
+  socket.on(Events.room_file_change_res, async (fileEventRequest: FileEventRequest) => {
     if (fileEventRequest.change.event === FileEvent.FILE_MODIFIED) {
       Console.green(`File patched: ${path.join('.shadow', fileEventRequest.change.path)}`);
       const patch = fileEventRequest.change as IPatch;
-      FS.applyPatchs(sourceFolderPath, patch);
+      await FS.applyPatches(sourceFolderPath, patch);
     } else {
       Console.green(`File changed: ${path.join('.shadow', fileEventRequest.change.path)}`);
       const fileChange = fileEventRequest.change as IFileChange;
-      FS.applyFileChange(sourceFolderPath, fileChange);
+      await FS.applyFileChange(sourceFolderPath, fileChange);
     }
   });
 

--- a/src/lib/common/FS.ts
+++ b/src/lib/common/FS.ts
@@ -1,21 +1,21 @@
 import * as Diff from 'diff';
-import readFileGo from 'readfile-go';
-
 import { IPatch, FileEvent, IFileChange } from './types';
 import * as path from 'path';
 import zipper from 'zip-local';
-import chokidar, { FSWatcher, WatchOptions } from 'chokidar';
-import { readFile, mkdirSync } from 'fs';
+import chokidar, { WatchOptions } from 'chokidar';
+import { readFile } from 'fs';
 import fse from 'fs-extra';
-import { Console } from '../utils/Console';
-export type FileSystemChangeType = { buffer: Buffer; path: string; event: FileEvent };
-export type SubscribeToChangeCallback = (input: IPatch) => void;
-export type SubscribeToCreateCallback = (input: IPatch) => void;
 
+/**
+ * This class contains static methods for manipulating files.
+ * In addition support for watching file changes.
+ */
 export class FS {
+
+  // These options are used when we initialize the directory watcher.
   private static readonly watchOptions: WatchOptions = {
     // This will ignore dotfiles for example .shadow (we need to add support for also ignoring binary files, images and so on).
-    ignored: /((^|[\/\\])\..)|(>|<|\?|\/|\\|\'|\*|\"|\|)/,
+    ignored: /(^|[\/\\])\../,
     // Indicates whether the process should continue to run as long as files are being watched.
     persistent: true,
     // When we begin to watch the source folder we can make sure that already existing files do not trigger a file change event.
@@ -24,31 +24,49 @@ export class FS {
 
   static readonly SHADOW_RELATIVE_PATH = '.shadow';
 
+  /**
+   * Takes in some compressed zip data and unzips it.
+   * @param buffer The data we want to unzip.
+   */
   protected static unzipBuffer(buffer: Buffer): Promise<any> {
     return new Promise((res, rej) => zipper.unzip(buffer, (error, data) => (error ? rej(error) : res(data))));
   }
 
+  /**
+   * This will unzip the data and save it.
+   * @param savePath where we should unzip and save the data.
+   * @param buffer the zip data.
+   */
   static async unzip(savePath: string, buffer: Buffer) {
     await fse.ensureDir(savePath);
     const unzipped = await this.unzipBuffer(buffer);
     await unzipped.save(savePath);
   }
 
+  /**
+   * This will zip a directory and return it as binary data.
+   * @param path the path to the directory we want to zip.
+   */
   static zip(path: string): Promise<Buffer> {
     return new Promise((res, rej) =>
       zipper.zip(path, (err, zipped) => (err ? rej(err) : res(zipped.compress().memory())))
     );
   }
 
-  static applyPatchs(sourceFolderPath: string, iPatch: IPatch) {
+  /**
+   * This method will apply a file patch in the shadow folder.
+   * @param source the source folder path.
+   * @param iPatch the file patch we want to apply in the shadow folder (this comes from the server).
+   */
+  static applyPatches(source: string, iPatch: IPatch) {
     return new Promise((resolve, reject) => {
       // For each specific file patch in the patch
-      iPatch.diffs.forEach(patch => {
+      iPatch.diffs.forEach(async patch => {
         // We split on any delimter and use the join function to
         // make sure that the delimiter which is used is the correct
         // for the OS.
-        const filePath = path.join(...patch.oldFileName.split(/\/|\\/g));
-        const oldData = readFileGo(filePath);
+        const filePath = path.join(source, this.SHADOW_RELATIVE_PATH, ...iPatch.path.split(/\/|\\/g));
+        const oldData = (await fse.readFile(filePath)).toString();
         const appliedData = Diff.applyPatch(oldData, patch);
 
         // Check wheter the patch is valid or not
@@ -56,86 +74,111 @@ export class FS {
 
         fse.writeFile(filePath, appliedData, err => {
           if (err) reject('could not write to file.');
-          else resolve();
+          else resolve(); // Resolve? Vad händer här egentligen / Marcus undrar! (TA bort kommentaren när marcus vet)
         });
       });
     });
   }
 
-  static getDiff(sourceFolderPath: string, shadowFolderPath: string, filePath: string) {
-    const shadowFile = path.join(shadowFolderPath, filePath);
-    const sourceFile = path.join(sourceFolderPath, filePath);
-    const shadowData = readFileGo(shadowFile);
-    const sourceData = readFileGo(sourceFile);
+  /**
+   * This method will compare two files and return the result.
+   * @param sourceFolderPath the source folder path.
+   * @param filePath the path to the file that we want to use in the comparison.
+   */
+  static async getDiff(source: string, filePath: string) {
+    const shadowFile = path.join(source, this.SHADOW_RELATIVE_PATH, filePath);
+    const sourceFile = path.join(source, filePath);
+    const shadowData = (await fse.readFile(shadowFile)).toString();
+    const sourceData = (await fse.readFile(sourceFile)).toString();
 
     const patchData = Diff.createTwoFilesPatch(shadowFile, sourceFile, shadowData, sourceData);
 
     return Diff.parsePatch(patchData);
   }
 
-  static listenForPatches(source: string, onPatch: (patch: IPatch) => void) {
+  /**
+   * By calling this method you will begin to listen for FILE_MODIFIED in the source folder directory.
+   * @param source the source folder path.
+   * @param onPatch a callback function that will be called upon a file patch.
+   */
+  static listenForLocalPatches(source: string, onPatch: (patch: IPatch) => void) {
     const watcher = chokidar.watch(source, FS.watchOptions);
-    watcher.on('change', filePath => {
-      const absoluteShadowPath = this.SHADOW_RELATIVE_PATH;
+    watcher.on('change', async filePath => {
       const relativeFilePath = path.relative(source, filePath);
-      const diffs = this.getDiff(source, absoluteShadowPath, relativeFilePath);
+      const diffs = await FS.getDiff(source, relativeFilePath);
       onPatch({ path: relativeFilePath, diffs, event: FileEvent.FILE_MODIFIED });
     });
   }
 
-  static listenForFileChanges(source: string, onFileChange: (fileChange: IFileChange) => void) {
+  /**
+   * By calling this method you will begin to listen for FILE_CREATED, FILE_DELETED, DIR_CREATED and DIR_DELETED in the source folder directory.
+   * @param source the source folder path.
+   * @param onFileChange a callback function that will be called upon a file change.
+   */
+  static listenForLocalFileChanges(source: string, onFileChange: (fileChange: IFileChange) => void) {
     const watcher = chokidar.watch(source, FS.watchOptions);
     watcher.on('all', (event, filePath) => {
-      // Checks that the event is one the select ones.
+      // This event is handled by patches.
       if (event == 'change') return;
 
+      // We don't want the source folder to be visible in the path.
+      // For example the file path: source-folder/dog.cpp, we just want to send /dog.cpp to the server.
       const relativeFilePath = path.relative(source, filePath);
 
+      // These events do not require us to read any file data.
       if (event === 'addDir' || event === 'unlink' || event === 'unlinkDir') {
         onFileChange({ path: relativeFilePath, event: event as FileEvent });
-        return;
+      } else {
+        // This code will be run for the FILE_CREATED event.
+        readFile(filePath, (err, buffer) => {
+          if (err) throw err;
+          else onFileChange({ buffer, path: relativeFilePath, event: event as FileEvent });
+        });
       }
-
-      readFile(filePath, (err, buffer) => {
-        if (err) throw err;
-        else onFileChange({ buffer, path: relativeFilePath, event: event as FileEvent });
-      });
     });
   }
 
-  static applyFileChange(sourceFolderPath: string, fileChange: IFileChange) {
+  /**
+   * This code will apply a file change in the shadow folder.
+   * @param source the source folder path.
+   * @param fileChange the file change we want to apply in the shadow folder (this comes from the server).
+   */
+  static async applyFileChange(source: string, fileChange: IFileChange): Promise<void> {
     const osSpecific = path.join(...fileChange.path.split(/\/|\\/g));
 
     switch (fileChange.event) {
       case FileEvent.FILE_DELETED: {
-        fse.remove(path.join(sourceFolderPath, FS.SHADOW_RELATIVE_PATH, osSpecific));
-        return;
+        return fse.remove(path.join(source, FS.SHADOW_RELATIVE_PATH, osSpecific));
       }
 
       case FileEvent.FILE_CREATED: {
-        const filePath = path.join(sourceFolderPath, FS.SHADOW_RELATIVE_PATH, osSpecific);
-        fse.ensureDirSync(path.dirname(filePath));
-        fse.writeFile(filePath, fileChange.buffer);
-        return;
+        const filePath = path.join(source, FS.SHADOW_RELATIVE_PATH, osSpecific);
+        await fse.ensureDir(path.dirname(filePath));
+        return fse.writeFile(filePath, fileChange.buffer);
       }
 
       case FileEvent.DIR_CREATED: {
-        const dirName = path.join(sourceFolderPath, FS.SHADOW_RELATIVE_PATH, osSpecific);
-        fse.ensureDirSync(dirName);
-        return;
+        const dirName = path.join(source, FS.SHADOW_RELATIVE_PATH, osSpecific);
+        return fse.ensureDir(dirName);
       }
 
       case FileEvent.DIR_DELETED: {
-        const dirName = path.join(sourceFolderPath, FS.SHADOW_RELATIVE_PATH, osSpecific);
-        fse.remove(dirName);
-        return;
+        const dirName = path.join(source, FS.SHADOW_RELATIVE_PATH, osSpecific);
+        return fse.remove(dirName);
       }
     }
+
+    throw new Error('Did not return in applyFileChange');
   }
 
-  static createShadow(folderPath: string, buffer: Buffer) {
-    const shadowPath = path.join(folderPath, FS.SHADOW_RELATIVE_PATH);
-    fse.emptyDirSync(shadowPath);
+  /**
+   * This method will create a new shadow folder and unzip a buffer into it.
+   * @param source the source folder path.
+   * @param buffer this is zip data (comes from the server).
+   */
+  static async createShadow(source: string, buffer: Buffer): Promise<void> {
+    const shadowPath = path.join(source, FS.SHADOW_RELATIVE_PATH);
+    await fse.emptyDir(shadowPath);
     return FS.unzip(shadowPath, buffer);
   }
 }

--- a/src/lib/common/FS.ts
+++ b/src/lib/common/FS.ts
@@ -146,27 +146,24 @@ export class FS {
    * @param fileChange the file change we want to apply in the shadow folder (this comes from the server).
    */
   static async applyFileChange(source: string, fileChange: IFileChange): Promise<void> {
-    const osSafeFilePath = path.join(...fileChange.path.split(/\/|\\/g));
+    const osSafeFilePath = path.join(source, FS.SHADOW_RELATIVE_PATH, ...fileChange.path.split(/\/|\\/g));
 
     switch (fileChange.event) {
       case FileEvent.FILE_DELETED: {
-        return fse.remove(path.join(source, FS.SHADOW_RELATIVE_PATH, osSafeFilePath));
+        return fse.remove(osSafeFilePath);
       }
 
       case FileEvent.FILE_CREATED: {
-        const filePath = path.join(source, FS.SHADOW_RELATIVE_PATH, osSafeFilePath);
-        await fse.ensureDir(path.dirname(filePath));
-        return fse.writeFile(filePath, fileChange.buffer);
+        await fse.ensureDir(path.dirname(osSafeFilePath));
+        return fse.writeFile(osSafeFilePath, fileChange.buffer);
       }
 
       case FileEvent.DIR_CREATED: {
-        const dirName = path.join(source, FS.SHADOW_RELATIVE_PATH, osSafeFilePath);
-        return fse.ensureDir(dirName);
+        return fse.ensureDir(osSafeFilePath);
       }
 
       case FileEvent.DIR_DELETED: {
-        const dirName = path.join(source, FS.SHADOW_RELATIVE_PATH, osSafeFilePath);
-        return fse.remove(dirName);
+        return fse.remove(osSafeFilePath);
       }
     }
 

--- a/src/lib/common/FS.ts
+++ b/src/lib/common/FS.ts
@@ -81,7 +81,7 @@ export class FS {
   }
 
   /**
-   * This method will compare two files and return the result.
+   * This method will compare two files and return the difference.
    * @param sourceFolderPath the source folder path.
    * @param filePath the path to the file that we want to use in the comparison.
    */

--- a/src/lib/common/FS.ts
+++ b/src/lib/common/FS.ts
@@ -32,14 +32,23 @@ export class FS {
   }
 
   /**
+   * Will save the zip file.
+   * @param unzipped the unzipped object.
+   * @param savePath where we should save the data.
+   */
+  protected static saveBuffer(unzipped: any, savePath: string): Promise<void> {
+    return new Promise<void>((res, rej) => unzipped.save(savePath, error => (error ? rej(error) : res())));
+  }
+
+  /**
    * This will unzip the data and save it.
    * @param savePath where we should unzip and save the data.
    * @param buffer the zip data.
    */
   static async unzip(savePath: string, buffer: Buffer): Promise<void> {
     await fse.ensureDir(savePath);
-    const unzipped = await this.unzipBuffer(buffer);
-    await unzipped.save(savePath);
+    const unzipped = await FS.unzipBuffer(buffer);
+    await FS.saveBuffer(unzipped, savePath);
   }
 
   /**
@@ -65,7 +74,7 @@ export class FS {
           // We split on any delimter and use the join function to
           // make sure that the delimiter which is used is the correct
           // for the OS.
-          const osSafeFilePath = path.join(source, this.SHADOW_RELATIVE_PATH, ...iPatch.path.split(/\/|\\/g));
+          const osSafeFilePath = path.join(source, FS.SHADOW_RELATIVE_PATH, ...iPatch.path.split(/\/|\\/g));
           fse.readFile(osSafeFilePath).then(buffer => {
             const appliedData = Diff.applyPatch(buffer.toString(), patch);
 
@@ -88,7 +97,7 @@ export class FS {
    * @param filePath the path to the file that we want to use in the comparison.
    */
   static async getDiff(source: string, filePath: string): Promise<Diff.ParsedDiff[]> {
-    const shadowFile = path.join(source, this.SHADOW_RELATIVE_PATH, filePath);
+    const shadowFile = path.join(source, FS.SHADOW_RELATIVE_PATH, filePath);
     const sourceFile = path.join(source, filePath);
     const shadowData = (await fse.readFile(shadowFile)).toString();
     const sourceData = (await fse.readFile(sourceFile)).toString();

--- a/src/lib/common/FS.ts
+++ b/src/lib/common/FS.ts
@@ -25,7 +25,7 @@ export class FS {
 
   /**
    * Takes in some compressed zip data and unzips it.
-   * @param buffer The data we want to unzip.
+   * @param buffer the data we want to unzip.
    */
   protected static unzipBuffer(buffer: Buffer): Promise<any> {
     return new Promise((res, rej) => zipper.unzip(buffer, (error, data) => (error ? rej(error) : res(data))));


### PR DESCRIPTION
Removed deprecated readfile-go, added comments and fixed minor errors (strange patch path that contained the source folder name).

I also removed everything that used sync methods and replaced them with async / await. What do you think of this approach?

In addition I have a question regarding the patch code in the method applyPatches. I have written a comment in that method. Check that out and give me an explanation.